### PR TITLE
docs: fix simple typo, attatch -> attach

### DIFF
--- a/cve-2020-0796-local/ntos.h
+++ b/cve-2020-0796-local/ntos.h
@@ -11038,7 +11038,7 @@ NtAllocateReserveObject(
 ************************************************************************************/
 
 //
-// Define the debug object thats used to attatch to processes that are being debugged.
+// Define the debug object thats used to attach to processes that are being debugged.
 //
 #define DEBUG_OBJECT_DELETE_PENDING (0x1) // Debug object is delete pending.
 #define DEBUG_OBJECT_KILL_ON_CLOSE  (0x2) // Kill all debugged processes on close


### PR DESCRIPTION
There is a small typo in cve-2020-0796-local/ntos.h.

Should read `attach` rather than `attatch`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md